### PR TITLE
Support newer Python versions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,7 @@ requirements:
     - python
     - pip
   run:
-    - python
-    - typing >=3.6.1  # [py<35]
+    - python>3.5 | python, typing >=3.6.1
     - mypy_extensions >=0.3.0
     - typing_extensions >=3.7.4
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
-  noarch: python
 
 requirements:
   host:
@@ -20,6 +19,7 @@ requirements:
     - pip
   run:
     - python
+    - typing >=3.7.4  # [py<35]
     - mypy_extensions >=0.3.0
     - typing_extensions >=3.7.4
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   noarch: python
-   
+
 requirements:
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - python
     - pip
   run:
-    - python >=3.5 | python < 3.5 , typing >= 3.6.1
+    - python >=3.5 | python <=3.4, typing >=3.6.1
     - mypy_extensions >=0.3.0
     - typing_extensions >=3.7.4
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - python
     - pip
   run:
-    - python>3.5 | python, typing >=3.6.1
+    - python >=3.5 | python < 3.5 , typing >= 3.6.1
     - mypy_extensions >=0.3.0
     - typing_extensions >=3.7.4
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - pip
   run:
     - python
-    - typing >=3.6.1 # [py<35]
+    - typing >=3.6.1  # [py<35]
     - mypy_extensions >=0.3.0
     - typing_extensions >=3.7.4
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - python
     - pip
   run:
-    - python >=3.5 | python <=3.4, typing >=3.6.1
+    - python
     - mypy_extensions >=0.3.0
     - typing_extensions >=3.7.4
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 811b44f92e780b90cfe7bac94249a4fae87cfaa9b40312765489255045231d9c
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   noarch: python
 
@@ -20,7 +20,7 @@ requirements:
     - pip
   run:
     - python
-    - typing >=3.6.1
+    - typing >=3.6.1 # [py<35]
     - mypy_extensions >=0.3.0
     - typing_extensions >=3.7.4
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,14 +12,14 @@ source:
 build:
   number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
-
+  noarch: python
+   
 requirements:
   host:
     - python
     - pip
   run:
     - python
-    - typing >=3.7.4  # [py<35]
     - mypy_extensions >=0.3.0
     - typing_extensions >=3.7.4
 


### PR DESCRIPTION
This current dependence on `typing` is preventing this package from being installed on Python > 3.5. This PR removes that dependency. It will be pulled in anyway b/c `typing_extensions` pulls it anyway: https://github.com/conda-forge/typing_extensions-feedstock/blob/7937f5c6284b2ade13ed7a98d74c6de43c30ab5f/recipe/meta.yaml#L25

I could have changed it to a conditional dependence on typing based on the Python version, but then this couldn't be a no-arch package.


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
